### PR TITLE
Buster dev

### DIFF
--- a/conf.d/patch-dpkg-gencontrol
+++ b/conf.d/patch-dpkg-gencontrol
@@ -84,6 +84,8 @@ case "$CODENAME" in
     wheezy)     wheezy_patch ;;
     jessie)     jessie_patch ;;
     stretch)    : ;; # uses overlayfs instead of aufs
+    buster)     : ;; # as above
+    bullseye)   : ;; # as above; hopefully... :)
     *) fatal "CODENAME is not set or not recognized" ;;
 esac
 

--- a/conf.d/patch-dpkg-gencontrol
+++ b/conf.d/patch-dpkg-gencontrol
@@ -78,12 +78,12 @@ EOF
 }
 
 case "$CODENAME" in
-    lucid) lucid_patch ;;
-    lenny) lenny_patch ;;
-    squeeze) squeeze_patch ;;
-    wheezy) wheezy_patch ;;
-    jessie) jessie_patch ;;
-    stretch) : ;; # uses overlayfs instead of aufs
+    lucid)      lucid_patch ;;
+    lenny)      lenny_patch ;;
+    squeeze)    squeeze_patch ;;
+    wheezy)     wheezy_patch ;;
+    jessie)     jessie_patch ;;
+    stretch)    : ;; # uses overlayfs instead of aufs
     *) fatal "CODENAME is not set or not recognized" ;;
 esac
 

--- a/plan/main
+++ b/plan/main
@@ -2,9 +2,10 @@ build-essential
 fakeroot
 debhelper
 cdbs
-git-core
+git                     /* git-core is now virtual pkg provided by git */
 aptitude
 docbook-utils
+texlive-formats-extra   /* provides virtual pkg jadetex - docbook-utils dep */
 xmlto
 unzip
 lsb-release
@@ -14,4 +15,5 @@ faketime
 /* pythondialog */
 python-all-dev
 python-all
-
+python3-all-dev         /* include py3 tools now in buster */
+python3-all             /* include py3 tools now in buster */

--- a/plan/main
+++ b/plan/main
@@ -9,6 +9,7 @@ texlive-formats-extra   /* provides virtual pkg jadetex - docbook-utils dep */
 xmlto
 unzip
 lsb-release
+dh-systemd              /* commonly required pacakge; so let's pre-install it */
 
 faketime
 
@@ -17,3 +18,6 @@ python-all-dev
 python-all
 python3-all-dev         /* include py3 tools now in buster */
 python3-all             /* include py3 tools now in buster */
+
+/* these are turnkey build dependends - best installed in buildroot from pool */
+turnkey-lazyclass


### PR DESCRIPTION
Updates for building packages for TurnKey v16.x (based on Debian Buster). Should be backwards compatible, at least for building v15.x (Debian Stretch based) buildroot.