### PR TITLE
Refactoring for bookworm (should still work with buster)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endef
 define root.patched/cleanup
         # kill stray processes
         fuser -k $O/root.patched || true;\
-		if [ -f $O/root.patched/turnkey-transition-info ]; then\
+		if [ -f $O/root.patched/turnkey-buildenv ]; then\
 			echo "note this is a transitional build, some functionality will be disabled";\
 		fi
 endef
@@ -53,6 +53,7 @@ endef
 install: pkg_install
 	rsync --delete -Hac $O/root.patched/ $(FAB_PATH)/buildroots/$$(basename $$RELEASE)/
 
+pkg_install: normal_pkg_install
 ifdef NO_TURNKEY_APT_REPO
 pkg_install: transition_pkg_install
 else
@@ -60,7 +61,6 @@ ifneq ($(HOST_RELEASE),$(RELEASE))
 $(info # transition detected - building $(RELEASE) on $(HOST_RELEASE))
 $(info # to disable TKL apt repos rerun with NO_TURNKEY_APT_REPO=y set)
 endif
-pkg_install: normal_pkg_install
 endif
 
 .PHONY: transition_pkg_install

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 #!/usr/bin/make -f
 # Copyright (c) 2020-2021 TurnKey GNU/Linux - https://www.turnkeylinux.org
 
-LOCAL_DISTRO := $(shell lsb_release -si | tr [A-Z] [a-z])
-LOCAL_CODENAME := $(shell lsb_release -sc)
-LOCAL_RELEASE := $(LOCAL_DISTRO)/$(LOCAL_CODENAME)
+HOST_DISTRO := $(shell lsb_release -si | tr [A-Z] [a-z])
+HOST_CODENAME := $(shell lsb_release -sc)
+HOST_DEB_VER := $(shell lsb_release -sr)
+HOST_RELEASE := $(HOST_DISTRO)/$(HOST_CODENAME)
 SHELL := /bin/bash
 
 ifndef RELEASE
-$(info RELEASE not defined - falling back to system: '$(LOCAL_RELEASE)')
-RELEASE := $(LOCAL_RELEASE)
+$(info RELEASE not defined - falling back to system: '$(HOST_RELEASE)')
+RELEASE := $(HOST_RELEASE)
 endif
 CERT_PATH := usr/local/share/ca-certificates
 
 # transitional related
-# note: these packages will be build & installed in the order they're defined
+# note: these packages will be built & installed in the order they're defined
 PACKAGES := turnkey-gitwrapper autoversion verseek turnkey-chroot
 
 .PHONY: complete
@@ -22,18 +23,22 @@ complete: pkg_install
 BUILDROOT := y
 FAB_SHARE_PATH ?= /usr/share/fab
 include $(FAB_SHARE_PATH)/product.mk
-
 # setup apt and dns for root.build
 define bootstrap/post
-	if [ -n "$(TRANSITION_NO_TURNKEY_APT_REPO)" ]; then \
-		echo "TRANSITION_NO_TURNKEY_APT_REPO" > $O/bootstrap/turnkey-transition-info; \
+	echo "export RELEASE=$(RELEASE)" > $O/bootstrap/turnkey-buildenv;
+	echo "export HOST_DEB_VER=$(HOST_DEB_VER)" >> $O/bootstrap/turnkey-buildenv;
+	if [ -n "$(NO_TURNKEY_APT_REPO)" ]; then \
+		echo "export NO_TURNKEY_APT_REPO=y" >> $O/bootstrap/turnkey-buildenv; \
+	fi
+	if [ -n "$(TKL_TESTING)" ]; then \
+		echo "export TKL_TESTING=y" >> $O/bootstrap/turnkey-buildenv; \
 	fi
 	fab-apply-overlay $(COMMON_OVERLAYS_PATH)/bootstrap_apt $O/bootstrap;
 	fab-chroot $O/bootstrap "echo nameserver 8.8.8.8 > /etc/resolv.conf";
 	fab-chroot $O/bootstrap "echo nameserver 8.8.4.4 >> /etc/resolv.conf";
 	mkdir -p $O/bootstrap/$(CERT_PATH);
 	# temporarily allow cert to not exist
-	cp /$(CERT_PATH)/squid_proxyCA.crt $O/bootstrap/$(CERT_PATH)/ || true; 
+	cp /$(CERT_PATH)/squid_proxyCA.crt $O/bootstrap/$(CERT_PATH)/ || true;
 	fab-chroot $O/bootstrap --script $(COMMON_CONF_PATH)/bootstrap_apt;
 endef
 
@@ -48,13 +53,15 @@ endef
 install: pkg_install
 	rsync --delete -Hac $O/root.patched/ $(FAB_PATH)/buildroots/$$(basename $$RELEASE)/
 
-ifneq ($(LOCAL_RELEASE),$(RELEASE))
-export TRANSITION_NO_TURNKEY_APT_REPO=y
+ifdef NO_TURNKEY_APT_REPO
 pkg_install: transition_pkg_install
 else
+ifneq ($(HOST_RELEASE),$(RELEASE))
+$(info # transition detected - building $(RELEASE) on $(HOST_RELEASE))
+$(info # to disable TKL apt repos rerun with NO_TURNKEY_APT_REPO=y set)
+endif
 pkg_install: normal_pkg_install
 endif
-
 
 .PHONY: transition_pkg_install
 transition_pkg_install: root.patched

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ out). E.g.::
 
 Note that this will build each of the TurnKey dependencies from source. If the
 source code isn't already available locally (in '/turnkey/public/${pkg}') it
-will be cloned there from GitHub.
+will be cloned there from GitHub (assuming internet access).
 
 If all the required TurnKey dependencies are available, but only in the
 turnkey-testing repo (as is likely early in the transition process), then

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Build buildroot for current release
 -----------------------------------
 
 This requires that the TurnKey dependencies have been built and uploaded to the
-TurnKey repos.::
+TurnKey repos (this should generally be the case).::
 
     make clean
     make
@@ -25,24 +25,48 @@ installs the buildroot to ``$FAB_PATH/buildroots/$(basename $RELEASE)``::
 Build buildroot for transition (new release)
 --------------------------------------------
 
-This assumes that the TurnKey dependencies are not yet available via the
-TurnKey apt repo. If the source code isn't already available locally
-(in '/turnkey/public/${pkg}') it will be cloned from GitHub.::
+When doing a distro transition (i.e. preparing for a new major version release
+- e.g. moving from one Debian release to the next), things are a little less
+straight forward. There are a number of TurnKey specific packages that are
+required and may not yet be built. If it's very early in the release, then the
+relevant TurnKey repos may not even exist yet.
+
+Before the relevant TurnKey apt repos exist, all TurnKey apt repos can be
+disabled by setting NO_TURNKEY_APT_REPO=y (all TKL apt lines will be commented
+out). E.g.::
 
     export RELEASE=debian/::CODENAME::
     make clean
-    make
+    NO_TURNKEY_APT_REPO=y make install
 
-Note by default this assumes the turnkeylinux repos are not available so will
-build each of the dependencies from source.
+Note that this will build each of the TurnKey dependencies from source. If the
+source code isn't already available locally (in '/turnkey/public/${pkg}') it
+will be cloned there from GitHub.
+
+If all the required TurnKey dependencies are available, but only in the
+turnkey-testing repo (as is likely early in the transition process), then
+set TKL_TESTING=y. E.g.::
+
+    export RELEASE=debian/::CODENAME::
+    make clean
+    TKL_TESTING=y make install
+
+If the TurnKey apt repos exist and the relevant packages are in the main
+TurnKey apt repo, then beyond the need to set the RELEASE, building for a
+transition is essentially the same as a normal build. I.e.::
+
+    export RELEASE=debian/::CODENAME::
+    make clean
+    make install
 
 Copy generated buildroot to buildroots folder
 ---------------------------------------------
 
-Once the buildroot is complete, then it needs to be copied to the desired
+Once the buildroot is built, then it needs to be copied to the desired
 location (default: ${FAB_PATH}/buildroots/::CODENAME::).
 
-Whether building a transition or not the ``install`` target does this for you::
+As noted above, whether building a transition or not the ``install`` target
+does this for you. I.e.::
 
     make install
 


### PR DESCRIPTION
Fair bit of refactoring for bookworm (hopefully with minimal regressions for earlier releases).

Changes (since @OnGle's recent work) include:
- replace `LOCAL_...` variable prefix with (more appropriate) `HOST_...` prefix
- introduce new `HOST_DEB_VER` env var (to capture host's Debian version number) - to assist detection of transition
- replace `TRANSITION_NO_TURNKEY_APT_REPO` with `NO_TURNKEY_APT_REPO` and swap default transition behaviour (i.e. default to assuming that repos exist)
- mechanism to pre-seed guest env vars via a `/turnkey-buildenv` env file (each line should be `export ENVAR_KEY=value` - essentially a refactor of @OnGle's use of a `/turnkey-transition-info` file)
- add support for setting `TKL_TESTING=y` - to enable turnkey-testing repo

Note related to / required by: https://github.com/turnkeylinux/common/pull/248
