### PR TITLE
remove a couple of packages that aren't used that often

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -5,8 +5,6 @@ debhelper
 cdbs
 git
 aptitude
-docbook-utils
-texlive-formats-extra   /* provides virtual pkg jadetex - docbook-utils dep */
 xmlto
 unzip
 lsb-release


### PR DESCRIPTION
Remove a couple of packages from plan (large packages and/or lots of dependencies) that are not used that often. They can be installed at build time if/when needed.